### PR TITLE
Update JLCPCB position alignment step size

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Use following table to quickly find out to which coordinate enter the correction
 |-90deg, Front or Back | down arrow | right arrow |
 
 For custom angles it's best to place also a temporary straight symbol to perform alignment.
-Single arrow press in JLC is about 0.07mm shift (8 clicks is about 0.5mm).
+Single arrow press in JLC is 0.0635mm (= 1/400in) shift.
 
 <img src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/blob/master/assets/position.png?raw=true" height=420>
 


### PR DESCRIPTION
After struggling for a while to accurately position components in one go, I finally decided to determine the step size of the component move arrows on JLCPCBs website more precisely. It looks like the step size is exactly 1/400 inches, or 0.0635mm.

How I determined this: I created a PCB with a long pin header (C18197918, 11x1 pins, pitch 2.54mm) and uploaded it to JLCPCB (Project files: [JLCPCB_Move_Step_Size.zip](https://github.com/bennymeg/Fabrication-Toolkit/files/15402165/JLCPCB_Move_Step_Size.zip))

![image](https://github.com/bennymeg/Fabrication-Toolkit/assets/33105866/004d43d4-09c8-4ea4-8101-0dd019b40b57)

After clicking the up button 400x, the connector is moved up like this (or rather, I selected the button via the browser Dev tools & ran `for (i=0;i<400;++i) $0.click()` in the JavaScript console to do it for me):

![image](https://github.com/bennymeg/Fabrication-Toolkit/assets/33105866/79d353a0-c1b0-4000-b015-e936a574e640)

This is exactly (11-1)x2.54mm, so 1in.
