### PR TITLE
Allow footprints with no pads

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -169,9 +169,8 @@ class ProcessManager:
                       or (footprint.GetValue().upper() == 'DNP') 
                       or getattr(footprint, 'IsDNP', bool)())
             skip_dnp = exclude_dnp and is_dnp
-            skip_footprint = footprint.GetPadCount() == 0
 
-            if not (footprint.GetAttributes() & pcbnew.FP_EXCLUDE_FROM_POS_FILES) and not skip_footprint and not is_dnp:
+            if not (footprint.GetAttributes() & pcbnew.FP_EXCLUDE_FROM_POS_FILES)  and not is_dnp:
                 # append unique ID if duplicate footprint designator
                 unique_id = ""
                 if footprint_designators[footprint.GetReference()] > 1:
@@ -214,7 +213,7 @@ class ProcessManager:
                     'Layer': layer,
                 })
 
-            if not (footprint.GetAttributes() & pcbnew.FP_EXCLUDE_FROM_BOM) and not skip_footprint and not skip_dnp:
+            if not (footprint.GetAttributes() & pcbnew.FP_EXCLUDE_FROM_BOM) and not skip_dnp:
                 # append unique ID if we are dealing with duplicate bom designator
                 unique_id = ""
                 if bom_designators[footprint.GetReference()] > 1:


### PR DESCRIPTION
Tohis should resolve issues like this one https://github.com/bennymeg/Fabrication-Toolkit/pull/138#issuecomment-2203491646 when people use dummy footprints (with no pads) as  a placeholder for actual parts. 

Btw, thanks [bennymeg](https://github.com/bennymeg) for adding `index out of range` protection in bounding box calculation https://github.com/bennymeg/Fabrication-Toolkit/commit/28ea32fedf48da7e14c69d56e46aa0caccb8b498.