### PR TITLE
Add support for addition common abbreviations for part number

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Add an 'LCSC Part #'* field with the LCSC component part number to the symbol's 
 <img src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/blob/master/assets/mpn.png?raw=true" height=420>
 
 #### Primary Fields*:
-| 'LCSC Part #' | 'LCSC Part' | 'JLCPCB Part #' | 'JLCPCB Part' |
-| --- | --- | --- | --- |
+| 'LCSC Part #' | 'LCSC Part' | 'LCSC PN' | 'LCSC P/N' | 'LCSC Part No.' | 'JLCPCB Part #' | 'JLCPCB Part' | 'JLCPCB PN' | 'JLCPCB P/N' | 'JLCPCB Part No.' |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 
 _The fields will be query in the order denoted above._
 

--- a/plugins/process.py
+++ b/plugins/process.py
@@ -406,7 +406,9 @@ class ProcessManager:
 
     def _get_mpn_from_footprint(self, footprint) -> str:
         ''''Get the MPN/LCSC stock code from standard symbol fields.'''
-        keys = ['LCSC Part #', 'LCSC Part', 'JLCPCB Part #', 'JLCPCB Part']
+        supplier_names = ['LCSC', 'JLCPCB']
+        pn_abbrevs = ['Part #', 'Part', 'PN', 'P/N', 'Part No.']
+        keys = [(sn + " " + abr) for sn in supplier_names for abr in pn_abbrevs]
         fallback_keys = ['LCSC', 'JLC', 'MPN', 'Mpn', 'mpn']
 
         if footprint_has_field(footprint, 'dnp'):


### PR DESCRIPTION
Currently, the plugin only supports abbreviating "Part Number" as "Part #" and as "Part". According to Wikipedia, part number is "often abbreviated PN, P/N, part no., or part #". This change adds support for using the abbreviations "PN", "P/N", and "Part No." to better integrate with more workflow stylistic choices.