### PR TITLE
Rename remaining files if gerber-zip gets a user defined name

### DIFF
--- a/plugins/thread.py
+++ b/plugins/thread.py
@@ -160,6 +160,11 @@ class ProcessThread(Thread):
         gerberArchiveName = ProcessManager.normalize_filename("_".join((baseName.strip() + '.zip').split()))
         os.rename(temp_file, os.path.join(temp_dir, gerberArchiveName))
 
+        if self.options[ARCHIVE_NAME]:
+            os.rename(os.path.join(temp_dir, designatorsFileName), os.path.join(temp_dir, ProcessManager.normalize_filename("_".join((baseName.strip() + '_designators.csv').split()))))
+            os.rename(os.path.join(temp_dir, placementFileName), os.path.join(temp_dir, ProcessManager.normalize_filename("_".join((baseName.strip() + '_positions.csv').split()))))
+            os.rename(os.path.join(temp_dir, bomFileName), os.path.join(temp_dir, ProcessManager.normalize_filename("_".join((baseName.strip() + '_bom.csv').split()))))
+
         timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H-%M-%S')
         backup_name = ProcessManager.normalize_filename("_".join(("{} {}".format(baseName, timestamp).strip()).split()))
         shutil.make_archive(os.path.join(output_path, 'backups', backup_name), 'zip', temp_dir)


### PR DESCRIPTION
ATM, only the gerber zip-file gets renamed if one specifies a custom name (e.g ${TITLE}_${REVISION}).

The other files like bom.csv are not renamed accordingly.
Hence, they get overwritten every single time.

This path add "_bom.csv",... to the basename if something like ${TITLE}_${REVISION} is given as the archive name in order to preserve the files for each revision.