### PR TITLE
[Feature] Cli arg for removing progress bar

### DIFF
--- a/plugins/cli.py
+++ b/plugins/cli.py
@@ -2,7 +2,7 @@ import argparse as ap
 
 from .thread import ProcessThread
 from .options import *
-   
+
 
 if __name__ == '__main__':
     parser = ap.ArgumentParser(prog="Fabrication Toolkit",
@@ -18,6 +18,7 @@ if __name__ == '__main__':
     parser.add_argument("--allActiveLayers",    "-aaL",action="store_true", help="Export all active layers instead of only commonly used ones")
     parser.add_argument("--archiveName",        "-aN", type=str, help="Name of the generated archives", metavar="NAME")
     parser.add_argument("--openBrowser",        "-b",  action="store_true", help="Open webbrowser with directory file overview after generation")
+    parser.add_argument("--nonInteractive",     "-nI" ,action="store_true", help="Run in non-Interactive mode. Usefull in CI/CD enviroment.")
     args = parser.parse_args()
 
     options = dict()
@@ -31,8 +32,9 @@ if __name__ == '__main__':
     options[EXTRA_LAYERS] = args.additionalLayers
 
     openBrowser = args.openBrowser
+    nonInteractive = args.nonInteractive
 
 
     path = args.path
 
-    ProcessThread(wx=None, cli=path, options=options, openBrowser=openBrowser)
+    ProcessThread(wx=None, cli=path, options=options, openBrowser=openBrowser, nonInteractive=nonInteractive)

--- a/plugins/thread.py
+++ b/plugins/thread.py
@@ -15,7 +15,7 @@ from .utils import print_cli_progress_bar
 
 
 class ProcessThread(Thread):
-    def __init__(self, wx, options, cli = None, openBrowser = True):
+    def __init__(self, wx, options, cli = None, openBrowser = True, nonInteractive = False):
         Thread.__init__(self)
 
         # prevent use of cli and grapgical mode at the same time
@@ -37,6 +37,7 @@ class ProcessThread(Thread):
         self.cli = cli
         self.options = options
         self.openBrowser = openBrowser
+        self.nonInteractive = nonInteractive
         self.start()
 
     def expandTextVariables(self, string):
@@ -182,6 +183,7 @@ class ProcessThread(Thread):
 
     def progress(self, percent):
         if self.wx is None:
-            print_cli_progress_bar(percent, prefix = 'Progress:', suffix = 'Complete', length = 50)
+            if not self.nonInteractive:
+                print_cli_progress_bar(percent, prefix = 'Progress:', suffix = 'Complete', length = 50)
         else:
             wx.PostEvent(self.wx, StatusEvent(percent))


### PR DESCRIPTION
Hello, firstly thank You for this amazing plugin. I just spined it inside CI and run across small problem with Progress Bar in CLI. When progress bar being printed, in terminal it is shown in one line which is constantly updated. Same does not count for CI, there progres  bar is printed to new line for each update and thus fill log so it become awfully long or hit CI LOG length limit, so another task are not logged.  So I added a argument for disabling it. It's probably  not a best solution, but works quite well for me.  I am open to other ideas.