### PR TITLE
Fix wrong rotations of footprints imported with easyeda2kicad

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -397,6 +397,11 @@ class ProcessManager:
             footprint: The footprint name
             lib_nickname: The library nickname, if available
         '''
+        # LCSC/EasyEDA footprints (library nickname like "C24639") already use
+        # JLCPCB's expected orientation, so skip the rotation correction database.
+        if lib_nickname and re.match(r'^C\d+$', lib_nickname):
+            return 0.0
+
         # First try with the standard approach for backward compatibility
         for entry in self.__rotation_db.items():
             # If the expression in the DB contains a :, search for it literally.
@@ -431,6 +436,10 @@ class ProcessManager:
             footprint: The footprint name
             lib_nickname: The library nickname, if available
         '''
+        # LCSC/EasyEDA footprints already use JLCPCB's expected orientation/position.
+        if lib_nickname and re.match(r'^C\d+$', lib_nickname):
+            return (0.0, 0.0)
+
         # First try with the standard approach for backward compatibility
         for entry in self.__rotation_db.items():
             # If the expression in the DB contains a :, search for it literally.


### PR DESCRIPTION
Footprints imported with easyeda2kicad already have the correct orientation and don't need the correction database

Solves: #231