### PR TITLE
feat: show user-defined layer names

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -78,7 +78,7 @@ class ProcessManager:
             extra_layers = []
 
         for layer_info in get_plot_plan(self.board):
-            if (self.board.IsLayerEnabled(layer_info[1]) and (all_active_layers or layer_info[1] in standardLayers)) or layer_info[0] in extra_layers:
+            if (self.board.IsLayerEnabled(layer_info[1]) and (all_active_layers or layer_info[1] in standardLayers)) or layer_info[2] in extra_layers:
                 plot_controller.SetLayer(layer_info[1])
                 plot_controller.OpenPlotfile(layer_info[2], pcbnew.PLOT_FORMAT_GERBER, layer_info[2])
 

--- a/plugins/utils.py
+++ b/plugins/utils.py
@@ -106,7 +106,7 @@ def get_plot_plan(board, active_only=True):
 def get_layer_names(board, active_only=True):
     """Returns a list of (active) layer names of the current board"""
     plotPlan = get_plot_plan(board, active_only)
-    return [layer_info[0] for layer_info in plotPlan]
+    return [layer_info[2] for layer_info in plotPlan]
 
 def print_cli_progress_bar(percent, prefix = '', suffix = '', decimals = 1, length = 100, fill = '█', printEnd = "\r"):
     """


### PR DESCRIPTION
This PR resolves #160, allowing users to now use the custom layer names when adding additional layers.

E.g. if you have renamed User.1 to "My.Custom.Name", instead of searching "User.1" you should now enter "My.Custom.Name".

This makes sense as this only affects people that have specifically renamed their layers. People who have done so would expect to use their own layer names, while not affecting those that haven't made any custom layer names.