### PR TITLE
Fix: backup generation logic inverted in thread.py

### DIFF
--- a/plugins/thread.py
+++ b/plugins/thread.py
@@ -171,7 +171,7 @@ class ProcessThread(Thread):
                 os.rename(os.path.join(temp_dir, bomFileName), os.path.join(temp_dir, ProcessManager.normalize_filename("_".join((baseName.strip() + '_bom.csv').split()))))
 
         # Make a backup as long as the BACKUP_OPT flag is set.
-        if not self.options[BACKUP_OPT]:
+        if self.options[BACKUP_OPT]:
             timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H-%M-%S')
             backup_name = ProcessManager.normalize_filename("_".join(("{} {}".format(baseName, timestamp).strip()).split()))
             shutil.make_archive(os.path.join(output_path, 'backups', backup_name), 'zip', temp_dir)


### PR DESCRIPTION
[Bug]: Backup generation logic is inverted (backup created when disabled, skipped when enabled)