### PR TITLE
Update process.py to support 'SPN' part number

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -461,7 +461,7 @@ class ProcessManager:
     def _get_mpn_from_footprint(self, footprint) -> str:
         ''''Get the MPN/LCSC stock code from standard symbol fields.'''
         supplier_names = ['LCSC', 'JLCPCB']
-        pn_abbrevs = ['Part #', 'Part', 'PN', 'P/N', 'Part No.', 'Part Number']
+        pn_abbrevs = ['Part #', 'Part', 'PN', 'P/N', 'Part No.', 'Part Number', 'SPN']
         keys = [(sn + " " + abr) for sn in supplier_names for abr in pn_abbrevs]
         fallback_keys = ['LCSC', 'JLC', 'MPN', 'Mpn', 'mpn']
 


### PR DESCRIPTION
'SPN' part number support makes Fabrication Toolkit compatible with 'LCSC SPN' part numbers generated by https://github.com/Part-DB/Part-DB-server

Without this modification Fabrication Toolkit uses MPN which contains the manufacturer part number in parts imported from Part-DB.